### PR TITLE
Allow for use of this gem outside of Rails

### DIFF
--- a/lib/codemirror-rails.rb
+++ b/lib/codemirror-rails.rb
@@ -1,1 +1,23 @@
+# When using outside of Rails.
+# Allows for using Rails asset pipline gems in other
+# projects setup to use sprockets, e.g. middlemanapp.com
+unless defined? ::Rails
+  module Rails
+    def self.version
+      "3.2.13"
+    end
+
+    def self.env
+      Class.new do
+        def test?
+          false
+        end
+      end.new
+    end
+
+    class Engine
+    end
+  end
+end
+
 require 'codemirror/rails'


### PR DESCRIPTION
I understand it may be a bit of an edge use case, but other utilities and libraries are starting to emerge such as middleman ( http://middlemanapp.com ) and code_sync ( http://datapimp.github.io/code_sync ) which allow for the usage of asset pipeline gems with Sprockets outside of Rails.

This small hack in the initial include of your gem is all that is necessary to support this.  I would appreciate it if you were able to include it in subsequent releases of this gem, as I have become spoiled by how easy it is to load codemirror into my projects with your gem.

Thank you.
