### PR TITLE
fixed typo

### DIFF
--- a/vendor/assets/stylesheets/codemirror/themes/yeti.css
+++ b/vendor/assets/stylesheets/codemirror/themes/yeti.css
@@ -59,7 +59,7 @@
   color: #9fb96e;
 }
 .cm-s-yeti span.cm-atom {
-  color:##a074c4;
+  color:#a074c4;
 }
 .cm-s-yeti span.cm-meta {
   color: #96c0d8;


### PR DESCRIPTION
fixed error:
Sass::SyntaxError: Invalid CSS after "  color:": expected expression (e.g. 1px, bold), was "##a074c4;"
  gems/codemirror-rails-5.5/vendor/assets/stylesheets/codemirror/themes/yeti.css