### PR TITLE
Fix typo at yeti.css

### DIFF
--- a/vendor/assets/stylesheets/codemirror/themes/yeti.css
+++ b/vendor/assets/stylesheets/codemirror/themes/yeti.css
@@ -59,7 +59,7 @@
   color: #9fb96e;
 }
 .cm-s-yeti span.cm-atom {
-  color:##a074c4;
+  color: #a074c4;
 }
 .cm-s-yeti span.cm-meta {
   color: #96c0d8;


### PR DESCRIPTION
Fix typo (double hash'ed color) that prevents Sass from compiling successfully...