### PR TITLE
proposed fix to allow haml mode to avoid choking on liquid style {% %}

### DIFF
--- a/vendor/assets/javascripts/codemirror/modes/haml.js
+++ b/vendor/assets/javascripts/codemirror/modes/haml.js
@@ -85,8 +85,10 @@
           state.tokenize = rubyInQuote(")");
           return state.tokenize(stream, state);
         } else if (ch == "{") {
-          state.tokenize = rubyInQuote("}");
-          return state.tokenize(stream, state);
+          if (!stream.match(/^\{%.*/)) {
+            state.tokenize = rubyInQuote("}");
+            return state.tokenize(stream, state);
+          }
         }
       }
 


### PR DESCRIPTION
Current behavior sees the closing %} as a haml tag begin.
The result is that the rest of the file after the %} doesnt highlight correctly.
Proposed fix: Dont go into quote mode when stream is '{%'. 